### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0-dev.1](https://github.com/Veetaha/marker/compare/marker_api-v0.3.0-dev...marker_api-v0.3.0-dev.1) - 2023-09-03
+
+### Other
+- More fixes in grammar and wording
+- Fix wording
+- Fixes from the review
+- Fix small typos and grammar mistakes
+- Improve error handling and observability
+
 
 ## [0.2.1] - 2023-08-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_marker"
-version = "0.3.0-dev"
+version = "0.3.0-dev.1"
 dependencies = [
  "camino",
  "cargo_metadata 0.17.0",
@@ -483,7 +483,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "marker_adapter"
-version = "0.3.0-dev"
+version = "0.3.0-dev.1"
 dependencies = [
  "libloading",
  "marker_api",
@@ -495,14 +495,14 @@ dependencies = [
 
 [[package]]
 name = "marker_api"
-version = "0.3.0-dev"
+version = "0.3.0-dev.1"
 dependencies = [
  "visibility",
 ]
 
 [[package]]
 name = "marker_error"
-version = "0.3.0-dev"
+version = "0.3.0-dev.1"
 dependencies = [
  "miette",
  "thiserror",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "marker_lints"
-version = "0.3.0-dev"
+version = "0.3.0-dev.1"
 dependencies = [
  "marker_api",
  "marker_uitest",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "marker_rustc_driver"
-version = "0.3.0-dev"
+version = "0.3.0-dev.1"
 dependencies = [
  "bumpalo",
  "marker_adapter",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "marker_uilints"
-version = "0.3.0-dev"
+version = "0.3.0-dev.1"
 dependencies = [
  "marker_api",
  "marker_uitest",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "marker_uitest"
-version = "0.3.0-dev"
+version = "0.3.0-dev.1"
 dependencies = [
  "semver",
  "tempfile",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "marker_utils"
-version = "0.3.0-dev"
+version = "0.3.0-dev.1"
 dependencies = [
  "marker_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition    = "2021"
 keywords   = ["marker", "lint"]
 license    = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-marker/marker"
-version    = "0.3.0-dev"
+version    = "0.3.0-dev.1"
 
 # The MSRV is applied to the public library crates published to crates.io
 rust-version = "1.66"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,15 @@
+[workspace]
+changelog_update = false
+
+[[package]]
+changelog_path   = "CHANGELOG.md"
+changelog_update = true
+name             = "marker_api"
+
+changelog_include = [
+  "marker_utils",
+  "marker_uitest",
+  "marker_error",
+  "marker_rustc_driver",
+  "cargo-marker",
+]


### PR DESCRIPTION
## 🤖 New release
* `cargo_marker`: 0.3.0-dev -> 0.3.0-dev.1
* `marker_error`: 0.3.0-dev -> 0.3.0-dev.1
* `marker_adapter`: 0.3.0-dev -> 0.3.0-dev.1
* `marker_api`: 0.3.0-dev -> 0.3.0-dev.1
* `marker_utils`: 0.3.0-dev -> 0.3.0-dev.1
* `marker_rustc_driver`: 0.3.0-dev -> 0.3.0-dev.1
* `marker_lints`: 0.3.0-dev -> 0.3.0-dev.1
* `marker_uitest`: 0.3.0-dev -> 0.3.0-dev.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `marker_api`
<blockquote>

## [0.3.0-dev.1](https://github.com/Veetaha/marker/compare/marker_api-v0.3.0-dev...marker_api-v0.3.0-dev.1) - 2023-09-03

### Other
- More fixes in grammar and wording
- Fix wording
- Fixes from the review
- Fix small typos and grammar mistakes
- Improve error handling and observability
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).